### PR TITLE
v1.4.2 — Payment methods, card filter, test fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![HA min version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2024.6-blue.svg)](https://www.home-assistant.io/)
-[![Version](https://img.shields.io/badge/version-1.4.1-blue.svg)](https://github.com/rolandzeiner/tankstellen-austria/releases)
+[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/rolandzeiner/tankstellen-austria/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 Home Assistant integration for Austrian fuel prices via the

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ payment_filter:
 | `show_opening_hours` | `true` | Show expandable opening hours on click |
 | `show_payment_methods` | `true` | Show payment method badges in expandable detail |
 | `show_history` | `true` | Show 7-day sparkline price graph (fixed mode only) |
-| `payment_filter` | `[]` | Only show stations accepting **all** listed methods. Values: `cash`, `debit_card`, `credit_card`, or any string from the API `others` field (e.g. `Austrocard`, `UTA`, `DKV`). Configurable via the visual editor. |
+| `payment_filter` | `[]` | Only show stations accepting **at least one** of the listed methods. Values: `cash`, `debit_card`, `credit_card`, or any string from the API `others` field (e.g. `Austrocard`, `UTA`, `DKV`). Configurable via the visual editor. |
 
 ### What the card shows
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ and/or CNG.
 ## Features
 
 - **Config-flow UI** – set up via the HA integrations page (map picker for coordinates)
-- **One sensor per fuel type** – state = cheapest price, attributes contain all 5 stations with name, address, opening hours, and Google Maps link
-- **Custom Lovelace card** – `tankstellen-austria-card` with fuel-type tabs, expandable opening hours, map links, and 7-day price sparkline
+- **One sensor per fuel type** – state = cheapest price, attributes contain all 5 stations with name, address, opening hours, payment methods, and Google Maps link
+- **Custom Lovelace card** – `tankstellen-austria-card` with fuel-type tabs, expandable detail panel (opening hours + payment methods), map links, and 7-day price sparkline
+- **Payment method filter** *(1.4.2)* – filter the card to show only stations accepting specific payment methods (cash, Bankomat, credit card, Austrocard, UTA, DKV, …)
 - **Auto-detection** – the card automatically finds all Tankstellen Austria sensors, no manual entity configuration needed
 - **Visual card editor** – configure everything through the HA UI
 - **Average price tracking** – average of all 5 stations as sensor attribute, tracked in HA history for long-term analysis
@@ -131,7 +132,11 @@ entities:
 max_stations: 3
 show_map_links: true
 show_opening_hours: true
+show_payment_methods: true
 show_history: true
+payment_filter:
+  - cash
+  - Austrocard
 ```
 
 ### Card options
@@ -143,7 +148,9 @@ show_history: true
 | `language` | HA language | `de` or `en` |
 | `show_map_links` | `true` | Show Google Maps link per station |
 | `show_opening_hours` | `true` | Show expandable opening hours on click |
+| `show_payment_methods` | `true` | Show payment method badges in expandable detail |
 | `show_history` | `true` | Show 7-day sparkline price graph (fixed mode only) |
+| `payment_filter` | `[]` | Only show stations accepting **all** listed methods. Values: `cash`, `debit_card`, `credit_card`, or any string from the API `others` field (e.g. `Austrocard`, `UTA`, `DKV`). Configurable via the visual editor. |
 
 ### What the card shows
 
@@ -151,9 +158,10 @@ show_history: true
 - Fuel type header with cheapest price and average price (Ø)
 - 7-day sparkline of cheapest price history with min/max labels
 - Station list ranked by price with name, address, and map link
-- Opening hours expandable per station on click
+- Expandable detail panel per station (click to open): opening hours + payment method badges
 - **Closed** badge (red) on currently closed stations
 - **Closing Soon** badge (amber) on stations closing within 30 minutes
+- Optional **payment filter** — hide stations that don't accept required methods
 
 **Dynamic mode (additional/different):**
 - Tab label includes tracker name — e.g. "Diesel · iPhone"
@@ -177,9 +185,23 @@ Each fuel type creates one sensor:
 | `fuel_type_name` | Diesel / Super 95 / CNG Erdgas |
 | `station_count` | Number of stations with prices |
 | `average_price` | Average price across all stations |
-| `stations` | List of station objects (id, name, price, open, location, opening_hours) |
+| `stations` | List of station objects (id, name, price, open, location, opening_hours, payment_methods) |
 | `dynamic_mode` | `true` when the entry tracks a device_tracker entity |
 | `dynamic_entity` | Entity ID of the tracked device_tracker (dynamic mode only) |
+
+Each station object in `stations` includes a `payment_methods` dict:
+
+```yaml
+payment_methods:
+  cash: true
+  debit_card: true
+  credit_card: false
+  others:
+    - Austrocard
+    - UTA
+```
+
+This can be used directly in automations and templates, e.g. to alert when the cheapest station doesn't accept your preferred card.
 
 ## API Info
 

--- a/custom_components/tankstellen_austria/const.py
+++ b/custom_components/tankstellen_austria/const.py
@@ -30,7 +30,7 @@ DYNAMIC_SAFETY_INTERVAL_HOURS = 6      # fallback timer when no movement detecte
 # Key inside hass.data[DOMAIN] for cross-entry rate limiting
 DOMAIN_LAST_API_CALL_KEY = "last_api_call"
 
-CARD_VERSION = "1.4.1"
+CARD_VERSION = "1.4.2"
 
 # Retry delay when the API returns no station data (e.g. mid-update window)
 NO_DATA_RETRY_MINUTES = 10

--- a/custom_components/tankstellen_austria/manifest.json
+++ b/custom_components/tankstellen_austria/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/rolandzeiner/tankstellen-austria/issues",
   "requirements": [],
-  "version": "1.4.1"
+  "version": "1.4.2"
 }

--- a/custom_components/tankstellen_austria/sensor.py
+++ b/custom_components/tankstellen_austria/sensor.py
@@ -13,6 +13,20 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import CONF_FUEL_TYPES, FUEL_TYPES
 from .coordinator import TankstellenCoordinator
 
+
+def _parse_payment_methods(raw: dict | None) -> dict:
+    """Normalise the paymentMethods API dict into a consistent structure."""
+    if not raw:
+        return {"cash": False, "debit_card": False, "credit_card": False, "others": []}
+    others_raw = raw.get("others") or ""
+    others = [o.strip() for o in others_raw.split(",") if o.strip()]
+    return {
+        "cash": bool(raw.get("cash")),
+        "debit_card": bool(raw.get("debitCard")),
+        "credit_card": bool(raw.get("creditCard")),
+        "others": others,
+    }
+
 PARALLEL_UPDATES = 0
 
 
@@ -87,6 +101,7 @@ class TankstellenSensor(CoordinatorEntity, SensorEntity):
                 "open": s.get("open"),
                 "location": s.get("location", {}),
                 "opening_hours": s.get("openingHours", []),
+                "payment_methods": _parse_payment_methods(s.get("paymentMethods")),
             })
         prices = [s["price"] for s in attr_stations if s.get("price") is not None]
         avg_price = round(sum(prices) / len(prices), 3) if prices else None

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -1,10 +1,10 @@
 /**
- * Tankstellen Austria Card v1.4.1
+ * Tankstellen Austria Card v1.4.2
  * Custom Lovelace card for displaying Austrian fuel prices.
  * https://github.com/rolandzeiner/tankstellen-austria
  */
 
-const CARD_VERSION = "1.4.1";
+const CARD_VERSION = "1.4.2";
 
 const TRANSLATIONS = {
   de: {
@@ -15,6 +15,11 @@ const TRANSLATIONS = {
     closing_soon: "Schließt bald",
     open_now: "Geöffnet",
     opening_hours: "Öffnungszeiten",
+    payment: "Zahlung",
+    cash: "Bar",
+    debit_card: "Bankomat",
+    credit_card: "Kreditkarte",
+    payment_filter_active: "Zahlungsfilter aktiv",
     no_data: "Keine Daten verfügbar",
     mon_fri: "Mo–Fr",
     sat: "Sa",
@@ -35,7 +40,9 @@ const TRANSLATIONS = {
       max_stations: "Anzahl Tankstellen",
       show_map_links: "Google Maps Links anzeigen",
       show_opening_hours: "Öffnungszeiten anzeigen",
+      show_payment_methods: "Zahlungsarten anzeigen",
       show_history: "Preisverlauf anzeigen",
+      payment_filter: "Nur Stationen mit",
     },
   },
   en: {
@@ -46,6 +53,11 @@ const TRANSLATIONS = {
     closing_soon: "Closing soon",
     open_now: "Open",
     opening_hours: "Opening hours",
+    payment: "Payment",
+    cash: "Cash",
+    debit_card: "Debit card",
+    credit_card: "Credit card",
+    payment_filter_active: "Payment filter active",
     no_data: "No data available",
     mon_fri: "Mon–Fri",
     sat: "Sat",
@@ -66,7 +78,9 @@ const TRANSLATIONS = {
       max_stations: "Number of stations",
       show_map_links: "Show Google Maps links",
       show_opening_hours: "Show opening hours",
+      show_payment_methods: "Show payment methods",
       show_history: "Show price history",
+      payment_filter: "Only stations with",
     },
   },
 };
@@ -371,8 +385,10 @@ class TankstellenAustriaCard extends HTMLElement {
 
     const showMapLinks = this._config.show_map_links !== false;
     const showHours = this._config.show_opening_hours !== false;
+    const showPayment = this._config.show_payment_methods !== false;
     const showHistory = this._config.show_history !== false;
     const maxStations = Math.min(5, Math.max(1, parseInt(this._config.max_stations, 10) || 5));
+    const paymentFilter = this._config.payment_filter || [];
 
     let html = `<ha-card>`;
 
@@ -466,11 +482,17 @@ class TankstellenAustriaCard extends HTMLElement {
         </div>`;
     }
 
-    if (!stations.length) {
+    const filteredStations = stations.filter((s) =>
+      this._matchesPaymentFilter(s, paymentFilter)
+    );
+
+    if (!filteredStations.length && paymentFilter.length && stations.length) {
+      html += `<div class="empty">${this._t("payment_filter_active")} — ${this._t("no_data")}</div>`;
+    } else if (!filteredStations.length) {
       html += `<div class="empty">${this._t("no_data")}</div>`;
     } else {
       html += `<div class="stations">`;
-      stations.forEach((s, idx) => {
+      filteredStations.forEach((s, idx) => {
         const loc = s.location || {};
         const isExpanded = this._expandedStations.has(`${this._activeTab}-${idx}`);
         const expandClass = isExpanded ? "expanded" : "";
@@ -498,12 +520,17 @@ class TankstellenAustriaCard extends HTMLElement {
             : ""
           }
             </div>
-            ${showHours
-            ? `<div class="hours ${expandClass}">
-                    ${this._renderHours(s.opening_hours || [])}
-                  </div>`
-            : ""
-          }
+            ${(() => {
+              const hasHours = showHours && s.opening_hours && s.opening_hours.length;
+              const hasPm = showPayment && this._hasPaymentMethods(s.payment_methods);
+              if (!hasHours && !hasPm) return "";
+              return `<div class="station-detail ${expandClass}">
+                  <div class="detail-cols">
+                    ${hasHours ? `<div class="detail-col">${this._renderHours(s.opening_hours)}</div>` : ""}
+                    ${hasPm ? `<div class="detail-col">${this._renderPaymentMethods(s.payment_methods)}</div>` : ""}
+                  </div>
+                </div>`;
+            })()}
           </div>`;
       });
       html += `</div>`;
@@ -529,6 +556,40 @@ class TankstellenAustriaCard extends HTMLElement {
     if (fe) html += `<span class="day">${this._t("holiday")}</span><span>${fe.from} – ${fe.to}</span>`;
     html += `</div>`;
     return html;
+  }
+
+  _hasPaymentMethods(pm) {
+    if (!pm) return false;
+    return pm.cash || pm.debit_card || pm.credit_card || (pm.others && pm.others.length > 0);
+  }
+
+  _matchesPaymentFilter(s, filter) {
+    if (!filter || !filter.length) return true;
+    const pm = s.payment_methods || {};
+    return filter.every((method) => {
+      if (method === "cash") return pm.cash;
+      if (method === "debit_card") return pm.debit_card;
+      if (method === "credit_card") return pm.credit_card;
+      return (pm.others || []).some((o) => o.toLowerCase() === method.toLowerCase());
+    });
+  }
+
+  _renderPaymentMethods(pm) {
+    if (!pm) return "";
+    const cashSvg = `<svg viewBox="0 0 24 24" width="13" height="13" style="vertical-align:-2px"><path fill="currentColor" d="M2 9a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2H2zm10 2a3 3 0 1 1 0 6 3 3 0 0 1 0-6z"/></svg>`;
+    const cardSvg = `<svg viewBox="0 0 24 24" width="13" height="13" style="vertical-align:-2px"><path fill="currentColor" d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 5H4V7h16v2z"/></svg>`;
+    const badges = [];
+    if (pm.cash) badges.push(`<span class="pm-badge">${cashSvg} ${this._t("cash")}</span>`);
+    if (pm.debit_card) badges.push(`<span class="pm-badge">${cardSvg} ${this._t("debit_card")}</span>`);
+    if (pm.credit_card) badges.push(`<span class="pm-badge">${cardSvg} ${this._t("credit_card")}</span>`);
+    for (const other of (pm.others || [])) {
+      badges.push(`<span class="pm-badge pm-other">${other}</span>`);
+    }
+    if (!badges.length) return "";
+    return `<div class="pm-section">
+      <div class="pm-label">${this._t("payment")}</div>
+      <div class="pm-badges">${badges.join("")}</div>
+    </div>`;
   }
 
   _attachListeners() {
@@ -826,15 +887,23 @@ class TankstellenAustriaCard extends HTMLElement {
         background: var(--primary-color);
         color: var(--text-primary-color, #fff);
       }
-      .hours {
+      .station-detail {
         max-height: 0;
         overflow: hidden;
-        transition: max-height 0.25s ease, padding 0.25s ease;
+        transition: max-height 0.3s ease, padding 0.3s ease;
         padding: 0 16px 0 52px;
       }
-      .hours.expanded {
-        max-height: 120px;
+      .station-detail.expanded {
+        max-height: 200px;
         padding: 0 16px 12px 52px;
+      }
+      .detail-cols {
+        display: flex;
+        gap: 16px;
+      }
+      .detail-col {
+        flex: 1;
+        min-width: 0;
       }
       .hours-grid {
         display: grid;
@@ -846,6 +915,35 @@ class TankstellenAustriaCard extends HTMLElement {
       .hours-grid .day {
         font-weight: 500;
         color: var(--primary-text-color);
+      }
+      .pm-section {
+        display: flex;
+        flex-direction: column;
+        gap: 6px;
+      }
+      .pm-label {
+        font-size: 12px;
+        font-weight: 500;
+        color: var(--primary-text-color);
+      }
+      .pm-badges {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+      }
+      .pm-badge {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        padding: 2px 7px;
+        border-radius: 10px;
+        font-size: 11px;
+        background: var(--secondary-background-color, #f5f5f5);
+        color: var(--secondary-text-color);
+        border: 1px solid var(--divider-color, #e0e0e0);
+      }
+      .pm-badge.pm-other {
+        font-style: italic;
       }
       .empty {
         padding: 24px 16px;
@@ -870,7 +968,9 @@ class TankstellenAustriaCard extends HTMLElement {
       max_stations: 5,
       show_map_links: true,
       show_opening_hours: true,
+      show_payment_methods: true,
       show_history: true,
+      payment_filter: [],
     };
   }
 }
@@ -917,7 +1017,18 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     const maxStations = this._config.max_stations ?? 5;
     const showMap = this._config.show_map_links !== false;
     const showHours = this._config.show_opening_hours !== false;
+    const showPayment = this._config.show_payment_methods !== false;
     const showHistory = this._config.show_history !== false;
+    const paymentFilter = this._config.payment_filter || [];
+
+    // Gather all payment methods available across current entity states
+    const allPmKeys = new Set(["cash", "debit_card", "credit_card"]);
+    (this._config.entities || []).forEach((eid) => {
+      const state = this._hass?.states[eid];
+      (state?.attributes?.stations || []).forEach((s) => {
+        (s.payment_methods?.others || []).forEach((o) => allPmKeys.add(o));
+      });
+    });
 
     this.innerHTML = `
       <div class="editor">
@@ -1004,6 +1115,29 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             font-size: 14px;
             color: var(--primary-text-color);
           }
+          .pm-filter-chips {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+          }
+          .pm-filter-chip {
+            padding: 4px 10px;
+            border-radius: 14px;
+            font-size: 12px;
+            cursor: pointer;
+            border: 1px solid var(--divider-color);
+            background: transparent;
+            color: var(--primary-text-color);
+            transition: all 0.15s;
+          }
+          .pm-filter-chip.active {
+            background: var(--primary-color);
+            color: var(--text-primary-color, #fff);
+            border-color: var(--primary-color);
+          }
+          .pm-filter-chip:hover {
+            opacity: 0.85;
+          }
         </style>
 
         <div class="editor-title">Tankstellen Austria</div>
@@ -1046,8 +1180,28 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             <ha-switch id="toggle-hours" ${showHours ? "checked" : ""} data-field="show_opening_hours"></ha-switch>
           </div>
           <div class="toggle-row">
+            <label for="toggle-payment">${this._et("show_payment_methods")}</label>
+            <ha-switch id="toggle-payment" ${showPayment ? "checked" : ""} data-field="show_payment_methods"></ha-switch>
+          </div>
+          <div class="toggle-row">
             <label for="toggle-history">${this._et("show_history")}</label>
             <ha-switch id="toggle-history" ${showHistory ? "checked" : ""} data-field="show_history"></ha-switch>
+          </div>
+        </div>
+
+        <!-- Payment filter -->
+        <div class="editor-section">
+          <div class="editor-label">${this._et("payment_filter")}</div>
+          <div class="editor-hint">${paymentFilter.length ? "● " + paymentFilter.join(", ") : "–"}</div>
+          <div class="pm-filter-chips">
+            ${[...allPmKeys].map((key) => {
+              const isActive = paymentFilter.includes(key);
+              const label = key === "cash" ? this._et("cash_label") || "Cash"
+                : key === "debit_card" ? this._et("debit_label") || "Bankomat"
+                : key === "credit_card" ? this._et("credit_label") || "Kreditkarte"
+                : key;
+              return `<button class="pm-filter-chip ${isActive ? "active" : ""}" data-pm="${key}">${label}</button>`;
+            }).join("")}
           </div>
         </div>
       </div>
@@ -1088,6 +1242,22 @@ class TankstellenAustriaCardEditor extends HTMLElement {
         const field = e.target.dataset.field;
         this._config = { ...this._config, [field]: e.target.checked };
         this._fireChanged();
+      });
+    });
+
+    // Payment filter chips
+    this.querySelectorAll(".pm-filter-chip").forEach((chip) => {
+      chip.addEventListener("click", () => {
+        const key = chip.dataset.pm;
+        let current = [...(this._config.payment_filter || [])];
+        if (current.includes(key)) {
+          current = current.filter((k) => k !== key);
+        } else {
+          current.push(key);
+        }
+        this._config = { ...this._config, payment_filter: current };
+        this._fireChanged();
+        this._render();
       });
     });
   }

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -15,7 +15,7 @@ const TRANSLATIONS = {
     closing_soon: "Schließt bald",
     open_now: "Geöffnet",
     opening_hours: "Öffnungszeiten",
-    payment: "Zahlung",
+    payment: "Zahlungsarten",
     cash: "Bar",
     debit_card: "Bankomat",
     credit_card: "Kreditkarte",
@@ -42,7 +42,7 @@ const TRANSLATIONS = {
       show_opening_hours: "Öffnungszeiten anzeigen",
       show_payment_methods: "Zahlungsarten anzeigen",
       show_history: "Preisverlauf anzeigen",
-      payment_filter: "Nur Stationen mit",
+      payment_filter: "Nur Tankstellen mit",
     },
   },
   en: {
@@ -1196,9 +1196,10 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           <div class="pm-filter-chips">
             ${[...allPmKeys].map((key) => {
               const isActive = paymentFilter.includes(key);
-              const label = key === "cash" ? this._et("cash_label") || "Cash"
-                : key === "debit_card" ? this._et("debit_label") || "Bankomat"
-                : key === "credit_card" ? this._et("credit_label") || "Kreditkarte"
+              const _tl = (TRANSLATIONS[this._lang()] || TRANSLATIONS.de);
+              const label = key === "cash" ? _tl.cash
+                : key === "debit_card" ? _tl.debit_card
+                : key === "credit_card" ? _tl.credit_card
                 : key;
               return `<button class="pm-filter-chip ${isActive ? "active" : ""}" data-pm="${key}">${label}</button>`;
             }).join("")}

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -566,7 +566,7 @@ class TankstellenAustriaCard extends HTMLElement {
   _matchesPaymentFilter(s, filter) {
     if (!filter || !filter.length) return true;
     const pm = s.payment_methods || {};
-    return filter.every((method) => {
+    return filter.some((method) => {
       if (method === "cash") return pm.cash;
       if (method === "debit_card") return pm.debit_card;
       if (method === "credit_card") return pm.credit_card;

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -60,6 +60,8 @@ async def test_form_creates_entry(hass: HomeAssistant, mock_fetch) -> None:
     assert result["data"][CONF_LATITUDE] == 48.2082
     assert result["data"][CONF_LONGITUDE] == 15.6256
     assert result["data"][CONF_FUEL_TYPES] == ["DIE", "SUP"]
+    assert result["data"][CONF_INCLUDE_CLOSED] is True
+    assert result["data"][CONF_SCAN_INTERVAL] == 30
 
 
 async def test_form_accepts_zero_coordinates(hass: HomeAssistant, mock_fetch) -> None:
@@ -125,6 +127,7 @@ async def test_options_flow_updates(hass: HomeAssistant, mock_fetch) -> None:
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert entry.options[CONF_FUEL_TYPES] == ["DIE"]
     assert entry.options[CONF_SCAN_INTERVAL] == 60
+    assert entry.options[CONF_INCLUDE_CLOSED] is False
 
 
 async def test_form_cannot_connect(hass: HomeAssistant) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -97,6 +97,25 @@ async def test_api_failure_raises_update_failed(hass: HomeAssistant) -> None:
         await coordinator._async_update_data()
 
 
+async def test_config_entry_not_ready_on_first_refresh_failure(
+    hass: HomeAssistant,
+) -> None:
+    """When the API fails on first setup, the entry ends up in SETUP_RETRY state."""
+    from homeassistant.config_entries import ConfigEntryState
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.tankstellen_austria.coordinator.TankstellenCoordinator._fetch",
+        side_effect=Exception("connection refused"),
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+
+
 # ---------------------------------------------------------------------------
 # Dynamic mode — properties
 # ---------------------------------------------------------------------------

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -23,6 +23,12 @@ MOCK_STATION = {
     "location": {"latitude": 48.2082, "longitude": 15.6256},
     "prices": [{"amount": 1.459}],
     "openingHours": [{"day": "MO-FR", "from": "06:00", "to": "22:00"}],
+    "paymentMethods": {
+        "cash": True,
+        "debitCard": True,
+        "creditCard": False,
+        "others": "Austrocard, UTA",
+    },
 }
 
 MOCK_STATION_2 = {
@@ -153,6 +159,7 @@ async def test_sensor_stations_attribute(hass: HomeAssistant) -> None:
     assert s["open"] is True
     assert "location" in s
     assert "opening_hours" in s
+    assert "payment_methods" in s
 
 
 async def test_sensor_average_price_multiple_stations(hass: HomeAssistant) -> None:
@@ -179,6 +186,14 @@ async def test_sensor_average_price_multiple_stations(hass: HomeAssistant) -> No
 # ---------------------------------------------------------------------------
 
 
+async def test_sensor_include_closed_saved(hass: HomeAssistant) -> None:
+    """CONF_INCLUDE_CLOSED=False is correctly stored on the coordinator."""
+    entry = await _setup_entry(hass, {CONF_INCLUDE_CLOSED: False})
+    from custom_components.tankstellen_austria.coordinator import TankstellenCoordinator
+    coordinator: TankstellenCoordinator = entry.runtime_data
+    assert coordinator._include_closed is False
+
+
 async def test_sensor_dynamic_mode_attributes(hass: HomeAssistant) -> None:
     """Sensors expose dynamic_mode=True and dynamic_entity when in dynamic mode."""
     entry = MockConfigEntry(
@@ -200,3 +215,48 @@ async def test_sensor_dynamic_mode_attributes(hass: HomeAssistant) -> None:
     state = hass.states.get("sensor.test_diesel")
     assert state.attributes["dynamic_mode"] is True
     assert state.attributes["dynamic_entity"] == "device_tracker.phone"
+
+
+# ---------------------------------------------------------------------------
+# Payment methods
+# ---------------------------------------------------------------------------
+
+
+async def test_sensor_payment_methods_parsed(hass: HomeAssistant) -> None:
+    """paymentMethods API dict is normalised into a structured payment_methods attribute."""
+    await _setup_entry(hass)
+    state = hass.states.get("sensor.test_diesel")
+    pm = state.attributes["stations"][0]["payment_methods"]
+
+    assert pm["cash"] is True
+    assert pm["debit_card"] is True
+    assert pm["credit_card"] is False
+    assert pm["others"] == ["Austrocard", "UTA"]
+
+
+async def test_sensor_payment_methods_missing(hass: HomeAssistant) -> None:
+    """Stations without paymentMethods get a safe all-false fallback."""
+    station_no_pm = {
+        "id": 2,
+        "name": "Kein Payment",
+        "open": True,
+        "location": {"latitude": 48.2, "longitude": 15.6},
+        "prices": [{"amount": 1.499}],
+        "openingHours": [],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data=BASE_ENTRY_DATA, options={}, title="Test")
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.tankstellen_austria.coordinator.TankstellenCoordinator._fetch",
+        new_callable=AsyncMock,
+        return_value=[station_no_pm],
+    ):
+        await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    pm = hass.states.get("sensor.test_diesel").attributes["stations"][0]["payment_methods"]
+    assert pm["cash"] is False
+    assert pm["debit_card"] is False
+    assert pm["credit_card"] is False
+    assert pm["others"] == []


### PR DESCRIPTION
## Summary

- **Payment methods attribute** — each station in `extra_state_attributes` now exposes a structured `payment_methods` dict (`cash`, `debit_card`, `credit_card` booleans + `others` list parsed from the API's comma-separated string)
- **Card payment filter** — new `payment_filter` config option; hides stations that don't accept any of the listed methods (OR logic); configurable via the visual editor with auto-populated chips
- **Card detail panel** — expandable area restructured into two columns: opening hours + payment method badges (inline SVG icons for cash/card, pill badges for fleet cards like Austrocard/UTA/DKV)
- **Card toggles** — `show_payment_methods` toggle added to card config and visual editor
- **Test fixes** — options flow `CONF_INCLUDE_CLOSED` assertion gap fixed; config entry creation assertions completed; added `test_config_entry_not_ready_on_first_refresh_failure`; added `test_sensor_include_closed_saved`; added `test_sensor_payment_methods_parsed` / `_missing`

## Backwards compatibility

Fully backwards compatible — `payment_filter` defaults to `[]` (no filtering), `payment_methods` is additive to existing sensor attributes, existing config entries require no migration.

## Test plan

- [x] 37 tests pass (`pytest tests/`)
- [x] Tested on live HA instance (beta-1, beta-2)
- [x] Existing 1.4.1 config entries unaffected
- [x] Card renders correctly with and without payment data