### PR TITLE
v1.4.3 — Payment filter improvements, editor redesign, MDI icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![hacs_badge](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://github.com/hacs/integration)
 [![HA min version](https://img.shields.io/badge/Home%20Assistant-%3E%3D2024.6-blue.svg)](https://www.home-assistant.io/)
-[![Version](https://img.shields.io/badge/version-1.4.2-blue.svg)](https://github.com/rolandzeiner/tankstellen-austria/releases)
+[![Version](https://img.shields.io/badge/version-1.4.3-blue.svg)](https://github.com/rolandzeiner/tankstellen-austria/releases)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![vibe-coded](https://img.shields.io/badge/vibe-coded-ff69b4?logo=musicbrainz&logoColor=white)](https://en.wikipedia.org/wiki/Vibe_coding)
 
@@ -17,7 +17,9 @@ and/or CNG.
 - **Config-flow UI** – set up via the HA integrations page (map picker for coordinates)
 - **One sensor per fuel type** – state = cheapest price, attributes contain all 5 stations with name, address, opening hours, payment methods, and Google Maps link
 - **Custom Lovelace card** – `tankstellen-austria-card` with fuel-type tabs, expandable detail panel (opening hours + payment methods), map links, and 7-day price sparkline
-- **Payment method filter** *(1.4.2)* – filter the card to show only stations accepting specific payment methods (cash, Bankomat, credit card, Austrocard, UTA, DKV, …)
+- **Payment method filter** *(1.4.2)* – filter or highlight stations by accepted payment methods (cash, Bankomat, credit card, Austrocard, UTA, DKV, …)
+- **Payment highlight mode** *(1.4.3)* – switch between hiding non-matching stations (filter) and highlighting them with a green accent instead
+- **Custom payment method values** *(1.4.3)* – add fleet cards or other values not listed by nearby stations (e.g. Routex, DKV) directly in the card editor
 - **Auto-detection** – the card automatically finds all Tankstellen Austria sensors, no manual entity configuration needed
 - **Visual card editor** – configure everything through the HA UI
 - **Average price tracking** – average of all 5 stations as sensor attribute, tracked in HA history for long-term analysis
@@ -138,6 +140,7 @@ show_history: true
 payment_filter:
   - cash
   - Austrocard
+payment_highlight_mode: false
 ```
 
 ### Card options
@@ -151,7 +154,8 @@ payment_filter:
 | `show_opening_hours` | `true` | Show expandable opening hours on click |
 | `show_payment_methods` | `true` | Show payment method badges in expandable detail |
 | `show_history` | `true` | Show 7-day sparkline price graph (fixed mode only) |
-| `payment_filter` | `[]` | Only show stations accepting **at least one** of the listed methods. Values: `cash`, `debit_card`, `credit_card`, or any string from the API `others` field (e.g. `Austrocard`, `UTA`, `DKV`). Configurable via the visual editor. |
+| `payment_filter` | `[]` | Show/highlight stations accepting **at least one** of the listed methods. Values: `cash`, `debit_card`, `credit_card`, or any string from the API `others` field (e.g. `Austrocard`, `UTA`, `DKV`, `Routex`). Configurable via the visual editor. |
+| `payment_highlight_mode` | `false` | When `true`, matching stations are highlighted with a green accent instead of non-matching ones being hidden. |
 
 ### What the card shows
 
@@ -162,7 +166,8 @@ payment_filter:
 - Expandable detail panel per station (click to open): opening hours + payment method badges
 - **Closed** badge (red) on currently closed stations
 - **Closing Soon** badge (amber) on stations closing within 30 minutes
-- Optional **payment filter** — hide stations that don't accept required methods
+- Optional **payment filter** — hide stations that don't accept any of the required methods, or use **highlight mode** to keep all stations visible with matching ones accented in green
+- Custom payment values can be added in the editor (e.g. `Routex`, `DKV`) — common API values: `Austrocard`, `UTA`, `DKV`, `Routex`, `Fleetcard`, `ADAC`
 
 **Dynamic mode (additional/different):**
 - Tab label includes tracker name — e.g. "Diesel · iPhone"

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ show_history: true
 payment_filter:
   - cash
   - Austrocard
-payment_highlight_mode: false
+payment_highlight_mode: true
 ```
 
 ### Card options
@@ -150,12 +150,12 @@ payment_highlight_mode: false
 | `entities` | auto-detect | List of Tankstellen Austria sensor entities |
 | `max_stations` | `5` | Number of stations to show (1–5) |
 | `language` | HA language | `de` or `en` |
-| `show_map_links` | `true` | Show Google Maps link per station |
+| `show_map_links` | `true` | Show map link per station — opens Google Maps for addresses with a street number, Google Search otherwise |
 | `show_opening_hours` | `true` | Show expandable opening hours on click |
 | `show_payment_methods` | `true` | Show payment method badges in expandable detail |
 | `show_history` | `true` | Show 7-day sparkline price graph (fixed mode only) |
 | `payment_filter` | `[]` | Show/highlight stations accepting **at least one** of the listed methods. Values: `cash`, `debit_card`, `credit_card`, or any string from the API `others` field (e.g. `Austrocard`, `UTA`, `DKV`, `Routex`). Configurable via the visual editor. |
-| `payment_highlight_mode` | `false` | When `true`, matching stations are highlighted with a green accent instead of non-matching ones being hidden. |
+| `payment_highlight_mode` | `true` | When `true`, matching stations are highlighted with a green accent instead of non-matching ones being hidden. |
 
 ### What the card shows
 

--- a/custom_components/tankstellen_austria/const.py
+++ b/custom_components/tankstellen_austria/const.py
@@ -30,7 +30,7 @@ DYNAMIC_SAFETY_INTERVAL_HOURS = 6      # fallback timer when no movement detecte
 # Key inside hass.data[DOMAIN] for cross-entry rate limiting
 DOMAIN_LAST_API_CALL_KEY = "last_api_call"
 
-CARD_VERSION = "1.4.3-beta-1"
+CARD_VERSION = "1.4.3"
 
 # Retry delay when the API returns no station data (e.g. mid-update window)
 NO_DATA_RETRY_MINUTES = 10

--- a/custom_components/tankstellen_austria/const.py
+++ b/custom_components/tankstellen_austria/const.py
@@ -30,7 +30,7 @@ DYNAMIC_SAFETY_INTERVAL_HOURS = 6      # fallback timer when no movement detecte
 # Key inside hass.data[DOMAIN] for cross-entry rate limiting
 DOMAIN_LAST_API_CALL_KEY = "last_api_call"
 
-CARD_VERSION = "1.4.2"
+CARD_VERSION = "1.4.3-beta-1"
 
 # Retry delay when the API returns no station data (e.g. mid-update window)
 NO_DATA_RETRY_MINUTES = 10

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -45,6 +45,7 @@ const TRANSLATIONS = {
       show_history: "Preisverlauf anzeigen",
       payment_filter: "Nur Tankstellen mit",
       payment_filter_custom_placeholder: "Benutzerdefiniert, z.B. Routex",
+      payment_filter_custom_hint: "Der Wert muss exakt dem API-String entsprechen. Häufige Werte: Routex, UTA, DKV, Austrocard, Fleetcard, ADAC",
       payment_highlight_mode: "Hervorheben statt filtern",
     },
   },
@@ -86,6 +87,7 @@ const TRANSLATIONS = {
       show_history: "Show price history",
       payment_filter: "Only stations with",
       payment_filter_custom_placeholder: "Custom, e.g. Routex",
+      payment_filter_custom_hint: "Must match the API string exactly. Common values: Routex, UTA, DKV, Austrocard, Fleetcard, ADAC",
       payment_highlight_mode: "Highlight instead of filter",
     },
   },
@@ -1259,6 +1261,7 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             <ha-textfield id="pm-custom-input" label="${this._et("payment_filter_custom_placeholder")}"></ha-textfield>
             <button id="pm-custom-add">+</button>
           </div>
+          <div class="editor-hint">${this._et("payment_filter_custom_hint")}</div>
           ${paymentFilter.length ? `
           <div class="toggle-row" style="margin-top:6px">
             <label for="toggle-highlight">${this._et("payment_highlight_mode")}</label>

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -1199,20 +1199,9 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           .pm-custom-row ha-textfield {
             flex: 1;
           }
-          .pm-custom-row button {
-            padding: 4px 12px;
-            border-radius: 8px;
-            border: 1px solid var(--primary-color);
-            background: transparent;
+          .pm-custom-row ha-icon-button {
             color: var(--primary-color);
-            font-size: 18px;
-            line-height: 1;
-            cursor: pointer;
-            transition: all 0.15s;
-          }
-          .pm-custom-row button:hover {
-            background: var(--primary-color);
-            color: var(--text-primary-color, #fff);
+            flex-shrink: 0;
           }
         </style>
 
@@ -1284,7 +1273,7 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           </div>
           <div class="pm-custom-row">
             <ha-textfield id="pm-custom-input" label="${this._et("payment_filter_custom_placeholder")}"></ha-textfield>
-            <button id="pm-custom-add">+</button>
+            <ha-icon-button id="pm-custom-add" title="+"><ha-icon icon="mdi:plus-circle"></ha-icon></ha-icon-button>
           </div>
           <div class="editor-hint">${this._et("payment_filter_custom_hint")}</div>
           ${paymentFilter.length ? `

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -1,10 +1,10 @@
 /**
- * Tankstellen Austria Card v1.4.3-beta-1
+ * Tankstellen Austria Card v1.4.3
  * Custom Lovelace card for displaying Austrian fuel prices.
  * https://github.com/rolandzeiner/tankstellen-austria
  */
 
-const CARD_VERSION = "1.4.3-beta-1";
+const CARD_VERSION = "1.4.3";
 
 const TRANSLATIONS = {
   de: {

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -1,10 +1,10 @@
 /**
- * Tankstellen Austria Card v1.4.2
+ * Tankstellen Austria Card v1.4.3-beta-1
  * Custom Lovelace card for displaying Austrian fuel prices.
  * https://github.com/rolandzeiner/tankstellen-austria
  */
 
-const CARD_VERSION = "1.4.2";
+const CARD_VERSION = "1.4.3-beta-1";
 
 const TRANSLATIONS = {
   de: {
@@ -20,6 +20,7 @@ const TRANSLATIONS = {
     debit_card: "Bankomat",
     credit_card: "Kreditkarte",
     payment_filter_active: "Zahlungsfilter aktiv",
+    payment_highlight_active: "Zahlungsfilter (Hervorhebung)",
     no_data: "Keine Daten verfügbar",
     mon_fri: "Mo–Fr",
     sat: "Sa",
@@ -43,6 +44,8 @@ const TRANSLATIONS = {
       show_payment_methods: "Zahlungsarten anzeigen",
       show_history: "Preisverlauf anzeigen",
       payment_filter: "Nur Tankstellen mit",
+      payment_filter_custom_placeholder: "Benutzerdefiniert, z.B. Routex",
+      payment_highlight_mode: "Hervorheben statt filtern",
     },
   },
   en: {
@@ -58,6 +61,7 @@ const TRANSLATIONS = {
     debit_card: "Debit card",
     credit_card: "Credit card",
     payment_filter_active: "Payment filter active",
+    payment_highlight_active: "Payment filter (highlight)",
     no_data: "No data available",
     mon_fri: "Mon–Fri",
     sat: "Sat",
@@ -81,6 +85,8 @@ const TRANSLATIONS = {
       show_payment_methods: "Show payment methods",
       show_history: "Show price history",
       payment_filter: "Only stations with",
+      payment_filter_custom_placeholder: "Custom, e.g. Routex",
+      payment_highlight_mode: "Highlight instead of filter",
     },
   },
 };
@@ -482,9 +488,11 @@ class TankstellenAustriaCard extends HTMLElement {
         </div>`;
     }
 
-    const filteredStations = stations.filter((s) =>
-      this._matchesPaymentFilter(s, paymentFilter)
-    );
+    const highlightMode = this._config.payment_highlight_mode === true;
+
+    const filteredStations = highlightMode
+      ? stations
+      : stations.filter((s) => this._matchesPaymentFilter(s, paymentFilter));
 
     if (!filteredStations.length && paymentFilter.length && stations.length) {
       html += `<div class="empty">${this._t("payment_filter_active")} — ${this._t("no_data")}</div>`;
@@ -503,9 +511,10 @@ class TankstellenAustriaCard extends HTMLElement {
           : isClosingSoon
             ? `<span class="badge closing-soon">${this._t("closing_soon")}</span>`
             : "";
+        const isHighlighted = highlightMode && paymentFilter.length && this._matchesPaymentFilter(s, paymentFilter);
 
         html += `
-          <div class="station">
+          <div class="station${isHighlighted ? " pm-highlight" : ""}">
             <div class="station-main" data-expand="${this._activeTab}-${idx}">
               <div class="rank">${idx + 1}</div>
               <div class="info">
@@ -644,6 +653,28 @@ class TankstellenAustriaCard extends HTMLElement {
     }
   }
 
+  _attachEditorListeners() {
+    const customInput = this.querySelector("#pm-custom-input");
+    const customAddBtn = this.querySelector("#pm-custom-add");
+    if (customAddBtn && customInput) {
+      const addCustom = () => {
+        const val = customInput.value.trim();
+        if (!val) return;
+        let current = [...(this._config.payment_filter || [])];
+        if (!current.includes(val)) {
+          current.push(val);
+          this._config = { ...this._config, payment_filter: current };
+          this._fireChanged();
+          this._render();
+        } else {
+          customInput.value = "";
+        }
+      };
+      customAddBtn.addEventListener("click", addCustom);
+      customInput.addEventListener("keydown", (e) => { if (e.key === "Enter") addCustom(); });
+    }
+  }
+
   _getStyles() {
     return `<style>
       ha-card {
@@ -765,6 +796,13 @@ class TankstellenAustriaCard extends HTMLElement {
       }
       .station:last-child {
         border-bottom: none;
+      }
+      .station.pm-highlight {
+        border-left: 3px solid var(--success-color, #4caf50);
+        background: rgba(76, 175, 80, 0.06);
+      }
+      .station.pm-highlight .station-main:hover {
+        background: rgba(76, 175, 80, 0.12);
       }
       .station-main {
         display: flex;
@@ -971,6 +1009,7 @@ class TankstellenAustriaCard extends HTMLElement {
       show_payment_methods: true,
       show_history: true,
       payment_filter: [],
+      payment_highlight_mode: false,
     };
   }
 }
@@ -1020,6 +1059,7 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     const showPayment = this._config.show_payment_methods !== false;
     const showHistory = this._config.show_history !== false;
     const paymentFilter = this._config.payment_filter || [];
+    const highlightMode = this._config.payment_highlight_mode === true;
 
     // Gather all payment methods available across current entity states
     const allPmKeys = new Set(["cash", "debit_card", "credit_card"]);
@@ -1029,6 +1069,8 @@ class TankstellenAustriaCardEditor extends HTMLElement {
         (s.payment_methods?.others || []).forEach((o) => allPmKeys.add(o));
       });
     });
+    // Ensure custom filter values always appear as chips even when not in live data
+    paymentFilter.forEach((f) => allPmKeys.add(f));
 
     this.innerHTML = `
       <div class="editor">
@@ -1138,6 +1180,33 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           .pm-filter-chip:hover {
             opacity: 0.85;
           }
+          .pm-custom-row {
+            display: flex;
+            gap: 6px;
+            margin-top: 4px;
+          }
+          .pm-custom-row input {
+            flex: 1;
+            padding: 4px 8px;
+            border-radius: 6px;
+            border: 1px solid var(--divider-color);
+            background: var(--card-background-color, #fff);
+            color: var(--primary-text-color);
+            font-size: 12px;
+          }
+          .pm-custom-row button {
+            padding: 4px 10px;
+            border-radius: 6px;
+            border: 1px solid var(--primary-color);
+            background: transparent;
+            color: var(--primary-color);
+            font-size: 12px;
+            cursor: pointer;
+          }
+          .pm-custom-row button:hover {
+            background: var(--primary-color);
+            color: var(--text-primary-color, #fff);
+          }
         </style>
 
         <div class="editor-title">Tankstellen Austria</div>
@@ -1204,6 +1273,15 @@ class TankstellenAustriaCardEditor extends HTMLElement {
               return `<button class="pm-filter-chip ${isActive ? "active" : ""}" data-pm="${key}">${label}</button>`;
             }).join("")}
           </div>
+          <div class="pm-custom-row">
+            <input type="text" id="pm-custom-input" placeholder="${this._et("payment_filter_custom_placeholder")}" />
+            <button id="pm-custom-add">+</button>
+          </div>
+          ${paymentFilter.length ? `
+          <div class="toggle-row" style="margin-top:6px">
+            <label for="toggle-highlight">${this._et("payment_highlight_mode")}</label>
+            <ha-switch id="toggle-highlight" ${highlightMode ? "checked" : ""} data-field="payment_highlight_mode"></ha-switch>
+          </div>` : ""}
         </div>
       </div>
     `;
@@ -1261,6 +1339,9 @@ class TankstellenAustriaCardEditor extends HTMLElement {
         this._render();
       });
     });
+
+    // Custom payment method input
+    this._attachEditorListeners();
   }
 }
 

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -47,6 +47,9 @@ const TRANSLATIONS = {
       payment_filter_custom_placeholder: "Benutzerdefiniert, z.B. Routex",
       payment_filter_custom_hint: "Der Wert muss exakt dem API-String entsprechen. Häufige Werte: Routex, UTA, DKV, Austrocard, Fleetcard, ADAC",
       payment_highlight_mode: "Hervorheben statt filtern",
+      section_sensors: "Sensoren",
+      section_display: "Anzeige",
+      section_payment_filter: "Zahlungsfilter",
     },
   },
   en: {
@@ -89,6 +92,9 @@ const TRANSLATIONS = {
       payment_filter_custom_placeholder: "Custom, e.g. Routex",
       payment_filter_custom_hint: "Must match the API string exactly. Common values: Routex, UTA, DKV, Austrocard, Fleetcard, ADAC",
       payment_highlight_mode: "Highlight instead of filter",
+      section_sensors: "Sensors",
+      section_display: "Display",
+      section_payment_filter: "Payment filter",
     },
   },
 };
@@ -1073,27 +1079,28 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             padding: 16px;
             display: flex;
             flex-direction: column;
-            gap: 16px;
-          }
-          .editor-title {
-            font-weight: 600;
-            font-size: 16px;
-            color: var(--primary-text-color);
+            gap: 12px;
           }
           .editor-section {
+            background: var(--secondary-background-color, rgba(0,0,0,0.04));
+            border-radius: 12px;
+            padding: 14px 16px;
             display: flex;
             flex-direction: column;
-            gap: 8px;
+            gap: 10px;
           }
-          .editor-label {
-            font-size: 13px;
-            font-weight: 500;
-            color: var(--primary-text-color);
+          .section-header {
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.6px;
+            text-transform: uppercase;
+            color: var(--secondary-text-color);
+            margin-bottom: 2px;
           }
           .editor-hint {
             font-size: 12px;
             color: var(--secondary-text-color);
-            margin-top: -4px;
+            line-height: 1.4;
           }
           .entity-chips {
             display: flex;
@@ -1104,13 +1111,13 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             display: flex;
             align-items: center;
             gap: 4px;
-            padding: 4px 10px;
+            padding: 5px 12px;
             border-radius: 16px;
             font-size: 13px;
             cursor: pointer;
             transition: all 0.15s;
             border: 1px solid var(--divider-color);
-            background: transparent;
+            background: var(--card-background-color, #fff);
             color: var(--primary-text-color);
           }
           .entity-chip.selected {
@@ -1128,12 +1135,17 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             display: flex;
             align-items: center;
             justify-content: space-between;
-            padding: 4px 0;
+            padding: 2px 0;
           }
           .toggle-row label {
             font-size: 13px;
             color: var(--primary-text-color);
             cursor: pointer;
+          }
+          .divider {
+            height: 1px;
+            background: var(--divider-color);
+            margin: 2px 0;
           }
           .slider-row {
             display: flex;
@@ -1149,7 +1161,7 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             text-align: center;
             font-weight: 600;
             font-size: 14px;
-            color: var(--primary-text-color);
+            color: var(--primary-color);
           }
           .pm-filter-chips {
             display: flex;
@@ -1157,12 +1169,12 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             gap: 6px;
           }
           .pm-filter-chip {
-            padding: 4px 10px;
+            padding: 4px 12px;
             border-radius: 14px;
             font-size: 12px;
             cursor: pointer;
             border: 1px solid var(--divider-color);
-            background: transparent;
+            background: var(--card-background-color, #fff);
             color: var(--primary-text-color);
             transition: all 0.15s;
           }
@@ -1183,19 +1195,20 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             display: flex;
             align-items: center;
             gap: 6px;
-            margin-top: 4px;
           }
           .pm-custom-row ha-textfield {
             flex: 1;
           }
           .pm-custom-row button {
-            padding: 4px 10px;
-            border-radius: 6px;
+            padding: 4px 12px;
+            border-radius: 8px;
             border: 1px solid var(--primary-color);
             background: transparent;
             color: var(--primary-color);
-            font-size: 12px;
+            font-size: 18px;
+            line-height: 1;
             cursor: pointer;
+            transition: all 0.15s;
           }
           .pm-custom-row button:hover {
             background: var(--primary-color);
@@ -1203,12 +1216,9 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           }
         </style>
 
-        <div class="editor-title">Tankstellen Austria</div>
-
         <!-- Entity selection -->
         <div class="editor-section">
-          <div class="editor-label">${this._et("entities")}</div>
-          <div class="editor-hint">${this._et("entities_hint")}</div>
+          <div class="section-header">${this._et("section_sensors")}</div>
           <div class="entity-chips">
             ${available.map((eid) => {
       const state = this._hass.states[eid];
@@ -1221,41 +1231,45 @@ class TankstellenAustriaCardEditor extends HTMLElement {
               </button>`;
     }).join("")}
           </div>
+          <div class="editor-hint">${this._et("entities_hint")}</div>
         </div>
 
-        <!-- Max stations slider -->
+        <!-- Display options -->
         <div class="editor-section">
-          <div class="editor-label">${this._et("max_stations")}</div>
-          <div class="slider-row">
-            <input type="range" min="1" max="5" step="1" value="${maxStations}" data-field="max_stations" />
-            <span class="slider-value">${maxStations}</span>
-          </div>
-        </div>
-
-        <!-- Toggles -->
-        <div class="editor-section">
+          <div class="section-header">${this._et("section_display")}</div>
           <div class="toggle-row">
             <label for="toggle-map">${this._et("show_map_links")}</label>
             <ha-switch id="toggle-map" ${showMap ? "checked" : ""} data-field="show_map_links"></ha-switch>
           </div>
+          <div class="divider"></div>
           <div class="toggle-row">
             <label for="toggle-hours">${this._et("show_opening_hours")}</label>
             <ha-switch id="toggle-hours" ${showHours ? "checked" : ""} data-field="show_opening_hours"></ha-switch>
           </div>
+          <div class="divider"></div>
           <div class="toggle-row">
             <label for="toggle-payment">${this._et("show_payment_methods")}</label>
             <ha-switch id="toggle-payment" ${showPayment ? "checked" : ""} data-field="show_payment_methods"></ha-switch>
           </div>
+          <div class="divider"></div>
           <div class="toggle-row">
             <label for="toggle-history">${this._et("show_history")}</label>
             <ha-switch id="toggle-history" ${showHistory ? "checked" : ""} data-field="show_history"></ha-switch>
           </div>
+          <div class="divider"></div>
+          <div class="toggle-row" style="padding-top:4px">
+            <label for="slider-stations">${this._et("max_stations")}</label>
+          </div>
+          <div class="slider-row">
+            <input id="slider-stations" type="range" min="1" max="5" step="1" value="${maxStations}" data-field="max_stations" />
+            <span class="slider-value">${maxStations}</span>
+          </div>
         </div>
 
-        <!-- Payment filter -->
+        <!-- Payment filter (only when show_payment_methods is on) -->
+        ${showPayment ? `
         <div class="editor-section">
-          <div class="editor-label">${this._et("payment_filter")}</div>
-          <div class="editor-hint">${paymentFilter.length ? "● " + paymentFilter.join(", ") : "–"}</div>
+          <div class="section-header">${this._et("section_payment_filter")}</div>
           <div class="pm-filter-chips">
             ${[...allPmKeys].map((key) => {
               const isActive = paymentFilter.includes(key);
@@ -1274,11 +1288,12 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           </div>
           <div class="editor-hint">${this._et("payment_filter_custom_hint")}</div>
           ${paymentFilter.length ? `
-          <div class="toggle-row" style="margin-top:6px">
+          <div class="divider"></div>
+          <div class="toggle-row">
             <label for="toggle-highlight">${this._et("payment_highlight_mode")}</label>
             <ha-switch id="toggle-highlight" ${highlightMode ? "checked" : ""} data-field="payment_highlight_mode"></ha-switch>
           </div>` : ""}
-        </div>
+        </div>` : ""}
       </div>
     `;
 

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -203,11 +203,17 @@ class TankstellenAustriaCard extends HTMLElement {
     return Number(price).toFixed(3).replace(".", ",");
   }
 
-  _mapsUrl(loc) {
+  _mapsUrl(loc, stationName) {
     if (!loc) return "#";
-    return `https://maps.google.com/?q=${encodeURIComponent(
-      `${loc.postalCode || ""} ${loc.city || ""} ${loc.address || ""}`
-    )}`;
+    const hasStreetNumber = /\d/.test(loc.address || "");
+    if (hasStreetNumber) {
+      return `https://maps.google.com/?q=${encodeURIComponent(
+        `${loc.postalCode || ""} ${loc.city || ""} ${loc.address || ""}`.trim()
+      )}`;
+    }
+    // No street number — fall back to Google search with station name + what we have
+    const parts = [stationName, loc.address, loc.postalCode, loc.city].filter(Boolean);
+    return `https://www.google.com/search?q=${encodeURIComponent(parts.join(" "))}`;
   }
 
   // --- History ---
@@ -531,7 +537,7 @@ class TankstellenAustriaCard extends HTMLElement {
               </div>
               <div class="price">${this._formatPrice(s.price)}</div>
               ${showMapLinks
-            ? `<a class="map-link" href="${this._mapsUrl(loc)}" target="_blank" rel="noopener noreferrer" title="${this._t("map")}">
+            ? `<a class="map-link" href="${this._mapsUrl(loc, s.name)}" target="_blank" rel="noopener noreferrer" title="${this._t("map")}">
                       <ha-icon icon="mdi:map-marker" class="map-icon"></ha-icon>
                     </a>`
             : ""

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -1168,17 +1168,12 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           }
           .pm-custom-row {
             display: flex;
+            align-items: center;
             gap: 6px;
             margin-top: 4px;
           }
-          .pm-custom-row input {
+          .pm-custom-row ha-textfield {
             flex: 1;
-            padding: 4px 8px;
-            border-radius: 6px;
-            border: 1px solid var(--divider-color);
-            background: var(--card-background-color, #fff);
-            color: var(--primary-text-color);
-            font-size: 12px;
           }
           .pm-custom-row button {
             padding: 4px 10px;
@@ -1261,7 +1256,7 @@ class TankstellenAustriaCardEditor extends HTMLElement {
             }).join("")}
           </div>
           <div class="pm-custom-row">
-            <input type="text" id="pm-custom-input" placeholder="${this._et("payment_filter_custom_placeholder")}" />
+            <ha-textfield id="pm-custom-input" label="${this._et("payment_filter_custom_placeholder")}"></ha-textfield>
             <button id="pm-custom-add">+</button>
           </div>
           ${paymentFilter.length ? `
@@ -1365,13 +1360,26 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           customInput.value = "";
         }
       };
-      // Stop propagation on all keyboard events so HA shortcuts don't steal focus
-      ["keydown", "keyup", "keypress"].forEach((evt) => {
-        customInput.addEventListener(evt, (e) => {
-          e.stopPropagation();
-          if (evt === "keydown" && e.key === "Enter") addCustom();
+      // ha-textfield uses shadow DOM — attach keyboard listeners to the internal
+      // input so stopPropagation prevents HA global shortcuts from stealing focus
+      const attachKeyListeners = () => {
+        const inner = customInput.shadowRoot?.querySelector("input");
+        if (!inner) return;
+        ["keydown", "keyup", "keypress"].forEach((evt) => {
+          inner.addEventListener(evt, (e) => {
+            e.stopPropagation();
+            if (evt === "keydown" && e.key === "Enter") addCustom();
+          });
         });
-      });
+      };
+      // ha-textfield may not be upgraded yet on first render
+      if (customInput.shadowRoot) {
+        attachKeyListeners();
+      } else {
+        customInput.addEventListener("connected", attachKeyListeners, { once: true });
+        // fallback: wait one microtask for upgrade
+        Promise.resolve().then(attachKeyListeners);
+      }
       customAddBtn.addEventListener("click", addCustom);
     }
   }

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -460,7 +460,7 @@ class TankstellenAustriaCard extends HTMLElement {
         <div class="card-header">
           <div class="header-top">
             <div class="fuel-label">
-              <svg viewBox="0 0 24 24" width="18" height="18" class="fuel-icon"><path fill="currentColor" d="M18 10a1 1 0 0 1-1-1 1 1 0 0 1 1-1 1 1 0 0 1 1 1 1 1 0 0 1-1 1m-6 0H8V5h4m7.77 2.23l.01-.01-3.72-3.72L15 4.56l2.11 2.11C16.17 7 15.5 7.93 15.5 9a2.5 2.5 0 0 0 2.5 2.5c.36 0 .69-.08 1-.21v7.21a1 1 0 0 1-1 1 1 1 0 0 1-1-1V14a2 2 0 0 0-2-2h-1V5a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v16h10v-7.5h1.5v5A2.5 2.5 0 0 0 20 21a2.5 2.5 0 0 0 2.5-2.5V9c0-.69-.28-1.32-.73-1.77z"/></svg>
+              <ha-icon icon="mdi:gas-station" class="fuel-icon"></ha-icon>
               <span>${fuelTypeName}</span>
             </div>
             ${isDynamic ? `
@@ -471,7 +471,7 @@ class TankstellenAustriaCard extends HTMLElement {
               </div>
             </div>
             <button class="refresh-btn${refreshCoolingDown ? " cooling" : ""}" data-refresh>
-              <svg viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M17.65 6.35A7.958 7.958 0 0 0 12 4c-4.42 0-7.99 3.58-7.99 8s3.57 8 7.99 8c3.73 0 6.84-2.55 7.73-6h-2.08A5.99 5.99 0 0 1 12 18c-3.31 0-6-2.69-6-6s2.69-6 6-6c1.66 0 3.14.69 4.22 1.78L13 11h7V4l-2.35 2.35z"/></svg>
+              <ha-icon icon="mdi:refresh" class="refresh-icon"></ha-icon>
               ${refreshCoolingDown ? countdownText : this._t("refresh")}
             </button>` : `
             <div class="header-prices">
@@ -526,7 +526,7 @@ class TankstellenAustriaCard extends HTMLElement {
               <div class="price">${this._formatPrice(s.price)}</div>
               ${showMapLinks
             ? `<a class="map-link" href="${this._mapsUrl(loc)}" target="_blank" rel="noopener noreferrer" title="${this._t("map")}">
-                      <svg viewBox="0 0 24 24" width="20" height="20"><path fill="currentColor" d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z"/></svg>
+                      <ha-icon icon="mdi:map-marker" class="map-icon"></ha-icon>
                     </a>`
             : ""
           }
@@ -587,12 +587,10 @@ class TankstellenAustriaCard extends HTMLElement {
 
   _renderPaymentMethods(pm) {
     if (!pm) return "";
-    const cashSvg = `<svg viewBox="0 0 24 24" width="13" height="13" style="vertical-align:-2px"><path fill="currentColor" d="M2 9a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h20a2 2 0 0 0 2-2v-8a2 2 0 0 0-2-2H2zm10 2a3 3 0 1 1 0 6 3 3 0 0 1 0-6z"/></svg>`;
-    const cardSvg = `<svg viewBox="0 0 24 24" width="13" height="13" style="vertical-align:-2px"><path fill="currentColor" d="M20 4H4c-1.1 0-2 .9-2 2v12c0 1.1.9 2 2 2h16c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 5H4V7h16v2z"/></svg>`;
     const badges = [];
-    if (pm.cash) badges.push(`<span class="pm-badge">${cashSvg} ${this._t("cash")}</span>`);
-    if (pm.debit_card) badges.push(`<span class="pm-badge">${cardSvg} ${this._t("debit_card")}</span>`);
-    if (pm.credit_card) badges.push(`<span class="pm-badge">${cardSvg} ${this._t("credit_card")}</span>`);
+    if (pm.cash) badges.push(`<span class="pm-badge"><ha-icon icon="mdi:cash" class="pm-icon"></ha-icon> ${this._t("cash")}</span>`);
+    if (pm.debit_card) badges.push(`<span class="pm-badge"><ha-icon icon="mdi:credit-card" class="pm-icon"></ha-icon> ${this._t("debit_card")}</span>`);
+    if (pm.credit_card) badges.push(`<span class="pm-badge"><ha-icon icon="mdi:credit-card" class="pm-icon"></ha-icon> ${this._t("credit_card")}</span>`);
     for (const other of (pm.others || [])) {
       badges.push(`<span class="pm-badge pm-other">${other}</span>`);
     }
@@ -723,6 +721,18 @@ class TankstellenAustriaCard extends HTMLElement {
       }
       .fuel-icon {
         color: var(--primary-color);
+        --mdc-icon-size: 18px;
+      }
+      .refresh-icon {
+        --mdc-icon-size: 16px;
+        vertical-align: middle;
+      }
+      .map-icon {
+        --mdc-icon-size: 20px;
+      }
+      .pm-icon {
+        --mdc-icon-size: 13px;
+        vertical-align: middle;
       }
       .header-prices {
         display: flex;

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -538,7 +538,7 @@ class TankstellenAustriaCard extends HTMLElement {
               <div class="price">${this._formatPrice(s.price)}</div>
               ${showMapLinks
             ? `<a class="map-link" href="${this._mapsUrl(loc, s.name)}" target="_blank" rel="noopener noreferrer" title="${this._t("map")}">
-                      <ha-icon icon="mdi:map-marker" class="map-icon"></ha-icon>
+                      <ha-icon icon="${/\d/.test(loc.address || "") ? "mdi:map-marker" : "mdi:magnify"}" class="map-icon"></ha-icon>
                     </a>`
             : ""
           }

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -1054,15 +1054,16 @@ class TankstellenAustriaCardEditor extends HTMLElement {
 
     const escHtml = (s) => String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
 
-    // Gather all payment methods available across current entity states
-    const allPmKeys = new Set(["cash", "debit_card", "credit_card"]);
+    // Keys available from live API data (builtin + whatever stations report)
+    const apiPmKeys = new Set(["cash", "debit_card", "credit_card"]);
     (this._config.entities || []).forEach((eid) => {
       const state = this._hass?.states[eid];
       (state?.attributes?.stations || []).forEach((s) => {
-        (s.payment_methods?.others || []).forEach((o) => allPmKeys.add(o));
+        (s.payment_methods?.others || []).forEach((o) => apiPmKeys.add(o));
       });
     });
-    // Ensure custom filter values always appear as chips even when not in live data
+    // allPmKeys also includes user-typed filter values not in live data
+    const allPmKeys = new Set([...apiPmKeys]);
     paymentFilter.forEach((f) => allPmKeys.add(f));
 
     this.innerHTML = `
@@ -1320,13 +1321,14 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     });
 
     // Payment filter chips
-    const builtinKeys = ["cash", "debit_card", "credit_card"];
+    // A chip needs confirmation only if removing it would make it disappear
+    // (i.e. it was user-typed and is not present in live API data)
     this.querySelectorAll(".pm-filter-chip").forEach((chip) => {
       chip.addEventListener("click", () => {
         const key = chip.dataset.pm;
         let current = [...(this._config.payment_filter || [])];
         const isActive = current.includes(key);
-        const isCustom = !builtinKeys.includes(key);
+        const isCustom = !apiPmKeys.has(key);
 
         if (isActive && isCustom) {
           if (this._pendingRemove === key) {

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -653,28 +653,6 @@ class TankstellenAustriaCard extends HTMLElement {
     }
   }
 
-  _attachEditorListeners() {
-    const customInput = this.querySelector("#pm-custom-input");
-    const customAddBtn = this.querySelector("#pm-custom-add");
-    if (customAddBtn && customInput) {
-      const addCustom = () => {
-        const val = customInput.value.trim();
-        if (!val) return;
-        let current = [...(this._config.payment_filter || [])];
-        if (!current.includes(val)) {
-          current.push(val);
-          this._config = { ...this._config, payment_filter: current };
-          this._fireChanged();
-          this._render();
-        } else {
-          customInput.value = "";
-        }
-      };
-      customAddBtn.addEventListener("click", addCustom);
-      customInput.addEventListener("keydown", (e) => { if (e.key === "Enter") addCustom(); });
-    }
-  }
-
   _getStyles() {
     return `<style>
       ha-card {
@@ -1341,7 +1319,25 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     });
 
     // Custom payment method input
-    this._attachEditorListeners();
+    const customInput = this.querySelector("#pm-custom-input");
+    const customAddBtn = this.querySelector("#pm-custom-add");
+    if (customAddBtn && customInput) {
+      const addCustom = () => {
+        const val = customInput.value.trim();
+        if (!val) return;
+        let current = [...(this._config.payment_filter || [])];
+        if (!current.includes(val)) {
+          current.push(val);
+          this._config = { ...this._config, payment_filter: current };
+          this._fireChanged();
+          this._render();
+        } else {
+          customInput.value = "";
+        }
+      };
+      customAddBtn.addEventListener("click", addCustom);
+      customInput.addEventListener("keydown", (e) => { if (e.key === "Enter") addCustom(); });
+    }
   }
 }
 

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -998,6 +998,7 @@ class TankstellenAustriaCard extends HTMLElement {
 class TankstellenAustriaCardEditor extends HTMLElement {
   _config = {};
   _hass = null;
+  _pendingRemove = null;
 
   setConfig(config) {
     this._config = { ...config };
@@ -1038,6 +1039,8 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     const showHistory = this._config.show_history !== false;
     const paymentFilter = this._config.payment_filter || [];
     const highlightMode = this._config.payment_highlight_mode === true;
+
+    const escHtml = (s) => String(s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;").replace(/"/g,"&quot;");
 
     // Gather all payment methods available across current entity states
     const allPmKeys = new Set(["cash", "debit_card", "credit_card"]);
@@ -1158,6 +1161,11 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           .pm-filter-chip:hover {
             opacity: 0.85;
           }
+          .pm-filter-chip.confirm {
+            background: var(--error-color, #db4437);
+            color: #fff;
+            border-color: var(--error-color, #db4437);
+          }
           .pm-custom-row {
             display: flex;
             gap: 6px;
@@ -1248,7 +1256,8 @@ class TankstellenAustriaCardEditor extends HTMLElement {
                 : key === "debit_card" ? _tl.debit_card
                 : key === "credit_card" ? _tl.credit_card
                 : key;
-              return `<button class="pm-filter-chip ${isActive ? "active" : ""}" data-pm="${key}">${label}</button>`;
+              const isPending = key === this._pendingRemove;
+              return `<button class="pm-filter-chip ${isActive ? "active" : ""} ${isPending ? "confirm" : ""}" data-pm="${escHtml(key)}">${isPending ? "✕ " + escHtml(label) + "?" : escHtml(label)}</button>`;
             }).join("")}
           </div>
           <div class="pm-custom-row">
@@ -1303,17 +1312,36 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     });
 
     // Payment filter chips
+    const builtinKeys = ["cash", "debit_card", "credit_card"];
     this.querySelectorAll(".pm-filter-chip").forEach((chip) => {
       chip.addEventListener("click", () => {
         const key = chip.dataset.pm;
         let current = [...(this._config.payment_filter || [])];
-        if (current.includes(key)) {
-          current = current.filter((k) => k !== key);
+        const isActive = current.includes(key);
+        const isCustom = !builtinKeys.includes(key);
+
+        if (isActive && isCustom) {
+          if (this._pendingRemove === key) {
+            // Second click: confirmed, remove
+            this._pendingRemove = null;
+            current = current.filter((k) => k !== key);
+            this._config = { ...this._config, payment_filter: current };
+            this._fireChanged();
+          } else {
+            // First click: enter confirm state
+            this._pendingRemove = key;
+          }
         } else {
-          current.push(key);
+          // Built-in chip or adding: toggle directly, cancel any pending
+          this._pendingRemove = null;
+          if (isActive) {
+            current = current.filter((k) => k !== key);
+          } else {
+            current.push(key);
+          }
+          this._config = { ...this._config, payment_filter: current };
+          this._fireChanged();
         }
-        this._config = { ...this._config, payment_filter: current };
-        this._fireChanged();
         this._render();
       });
     });
@@ -1322,9 +1350,11 @@ class TankstellenAustriaCardEditor extends HTMLElement {
     const customInput = this.querySelector("#pm-custom-input");
     const customAddBtn = this.querySelector("#pm-custom-add");
     if (customAddBtn && customInput) {
+      const sanitize = (s) => s.replace(/[<>"'&]/g, "").slice(0, 50).trim();
       const addCustom = () => {
-        const val = customInput.value.trim();
+        const val = sanitize(customInput.value);
         if (!val) return;
+        this._pendingRemove = null;
         let current = [...(this._config.payment_filter || [])];
         if (!current.includes(val)) {
           current.push(val);
@@ -1335,8 +1365,14 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           customInput.value = "";
         }
       };
+      // Stop propagation on all keyboard events so HA shortcuts don't steal focus
+      ["keydown", "keyup", "keypress"].forEach((evt) => {
+        customInput.addEventListener(evt, (e) => {
+          e.stopPropagation();
+          if (evt === "keydown" && e.key === "Enter") addCustom();
+        });
+      });
       customAddBtn.addEventListener("click", addCustom);
-      customInput.addEventListener("keydown", (e) => { if (e.key === "Enter") addCustom(); });
     }
   }
 }

--- a/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
+++ b/custom_components/tankstellen_austria/www/tankstellen-austria-card.js
@@ -999,7 +999,7 @@ class TankstellenAustriaCard extends HTMLElement {
       show_payment_methods: true,
       show_history: true,
       payment_filter: [],
-      payment_highlight_mode: false,
+      payment_highlight_mode: true,
     };
   }
 }
@@ -1373,26 +1373,15 @@ class TankstellenAustriaCardEditor extends HTMLElement {
           customInput.value = "";
         }
       };
-      // ha-textfield uses shadow DOM — attach keyboard listeners to the internal
-      // input so stopPropagation prevents HA global shortcuts from stealing focus
-      const attachKeyListeners = () => {
-        const inner = customInput.shadowRoot?.querySelector("input");
-        if (!inner) return;
-        ["keydown", "keyup", "keypress"].forEach((evt) => {
-          inner.addEventListener(evt, (e) => {
-            e.stopPropagation();
-            if (evt === "keydown" && e.key === "Enter") addCustom();
-          });
+      // Keyboard events from inside ha-textfield's shadow DOM bubble up as
+      // composed events, so we can intercept them on the host element.
+      // stopPropagation here prevents HA global shortcuts from stealing focus.
+      ["keydown", "keyup", "keypress"].forEach((evt) => {
+        customInput.addEventListener(evt, (e) => {
+          e.stopPropagation();
+          if (evt === "keydown" && e.key === "Enter") addCustom();
         });
-      };
-      // ha-textfield may not be upgraded yet on first render
-      if (customInput.shadowRoot) {
-        attachKeyListeners();
-      } else {
-        customInput.addEventListener("connected", attachKeyListeners, { once: true });
-        // fallback: wait one microtask for upgrade
-        Promise.resolve().then(attachKeyListeners);
-      }
+      });
       customAddBtn.addEventListener("click", addCustom);
     }
   }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -251,6 +251,45 @@ async def test_async_teardown_noop_for_fixed(hass: HomeAssistant) -> None:
 
 
 # ---------------------------------------------------------------------------
+# include_closed API param
+# ---------------------------------------------------------------------------
+
+
+async def test_include_closed_true_passed_to_api(hass: HomeAssistant) -> None:
+    """includeClosed=true is sent to the API when CONF_INCLUDE_CLOSED is True."""
+    entry = _make_entry({CONF_INCLUDE_CLOSED: True})
+    entry.add_to_hass(hass)
+
+    coordinator = TankstellenCoordinator(hass, entry)
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json = AsyncMock(return_value=[MOCK_STATION])
+
+    with patch.object(coordinator._session, "get", new=AsyncMock(return_value=mock_resp)) as mock_get:
+        await coordinator._fetch("DIE", 48.2082, 15.6256)
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["includeClosed"] == "true"
+
+
+async def test_include_closed_false_passed_to_api(hass: HomeAssistant) -> None:
+    """includeClosed=false is sent to the API when CONF_INCLUDE_CLOSED is False."""
+    entry = _make_entry({CONF_INCLUDE_CLOSED: False})
+    entry.add_to_hass(hass)
+
+    coordinator = TankstellenCoordinator(hass, entry)
+    mock_resp = MagicMock()
+    mock_resp.raise_for_status = MagicMock()
+    mock_resp.json = AsyncMock(return_value=[MOCK_STATION])
+
+    with patch.object(coordinator._session, "get", new=AsyncMock(return_value=mock_resp)) as mock_get:
+        await coordinator._fetch("DIE", 48.2082, 15.6256)
+
+    _, kwargs = mock_get.call_args
+    assert kwargs["params"]["includeClosed"] == "false"
+
+
+# ---------------------------------------------------------------------------
 # No-data retry
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -186,12 +186,20 @@ async def test_sensor_average_price_multiple_stations(hass: HomeAssistant) -> No
 # ---------------------------------------------------------------------------
 
 
-async def test_sensor_include_closed_saved(hass: HomeAssistant) -> None:
+async def test_sensor_include_closed_false_saved(hass: HomeAssistant) -> None:
     """CONF_INCLUDE_CLOSED=False is correctly stored on the coordinator."""
     entry = await _setup_entry(hass, {CONF_INCLUDE_CLOSED: False})
     from custom_components.tankstellen_austria.coordinator import TankstellenCoordinator
     coordinator: TankstellenCoordinator = entry.runtime_data
     assert coordinator._include_closed is False
+
+
+async def test_sensor_include_closed_true_saved(hass: HomeAssistant) -> None:
+    """CONF_INCLUDE_CLOSED=True (the default) is correctly stored on the coordinator."""
+    entry = await _setup_entry(hass, {CONF_INCLUDE_CLOSED: True})
+    from custom_components.tankstellen_austria.coordinator import TankstellenCoordinator
+    coordinator: TankstellenCoordinator = entry.runtime_data
+    assert coordinator._include_closed is True
 
 
 async def test_sensor_dynamic_mode_attributes(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- **Payment highlight mode** — toggle between hiding non-matching stations (filter) and highlighting matching ones with a green accent; highlight is now the default
- **Custom payment method values** — add fleet card values not listed by nearby stations (e.g. Routex, DKV) via a native `ha-textfield` input in the card editor; hint text lists common API values; sanitized and capped at 50 chars
- **Smart map link** — addresses without a street number open a Google Search (`mdi:magnify`) instead of a Google Maps pin that would resolve incorrectly
- **Card editor redesign** — sections styled as native HA cards with uppercase headers and dividers; payment filter section hidden when "Zahlungsarten anzeigen" is off; all interactive elements use native HA components (`ha-switch`, `ha-textfield`, `ha-icon-button`, `ha-icon`)
- **MDI icons** — all inline SVGs replaced with `ha-icon` throughout the card
- **Test coverage** — filled `include_closed` gap: both `true`/`false` verified at coordinator level and confirmed to reach the API `includeClosed` param

## Bug fixes

- Fixed reload banner looping after clicking "Neu laden" (`const.py CARD_VERSION` must match card JS version including beta suffix)
- Fixed `_attachEditorListeners is not a function` (method was on wrong class)
- Fixed HA keyboard shortcuts stealing focus while typing in custom input (shadow DOM)
- Fixed Enter key not adding custom chip (`ha-textfield` shadow DOM traversal)
- Fixed chip removal confirmation triggering on API-reported values (e.g. Austrocard) — confirmation now only applies to user-typed values that would disappear on removal

## Test plan

- [x] Install via HACS on dev branch, confirm "Tankstellen Austria was updated" reload banner appears and resolves cleanly
- [x] Card editor: confirm three distinct sections (Sensoren / Anzeige / Zahlungsfilter)
- [x] Zahlungsfilter section hidden when "Zahlungsarten anzeigen" toggle is off
- [x] Add a custom payment value (e.g. Routex) via text input — Enter key and + button both work
- [x] Custom chip shows red confirm state on first click, removes on second; built-in and API chips toggle freely
- [x] Station with incomplete address shows `mdi:magnify` icon linking to Google Search
- [x] Station with full address shows `mdi:map-marker` icon linking to Google Maps