### PR TITLE
chore: enable Dependabot on main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary

- Adds \`.github/dependabot.yml\` with two ecosystems:
  - **github-actions** — weekly, grouped into one PR to reduce noise
  - **pip** — weekly, covers \`requirements_test.txt\`
- Lands on \`main\` so Dependabot starts scanning the default branch immediately; the rest of the 1.6 cycle stays on \`dev\` until release.

Branch-pinned actions (\`hacs/action@main\`, \`home-assistant/actions/hassfest@master\`) are auto-ignored by Dependabot — that's intentional.

## Test plan

- [x] YAML is valid
- [ ] After merge: confirm Dependabot shows ecosystems in repo Insights → Dependency graph → Dependabot