### PR TITLE
refactor: Platinum compliance sweep — typed entry alias, explicit config_entry, canonical UA (Stage A)

### DIFF
--- a/custom_components/tankstellen_austria/__init__.py
+++ b/custom_components/tankstellen_austria/__init__.py
@@ -9,14 +9,13 @@ import voluptuous as vol
 from homeassistant.components import websocket_api
 from homeassistant.components.http import StaticPathConfig
 from homeassistant.components.websocket_api import ActiveConnection  # type: ignore[attr-defined]
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED, Platform
 from homeassistant.core import CoreState, Event, HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 
 from .const import CARD_VERSION, DOMAIN
-from .coordinator import TankstellenCoordinator
+from .coordinator import TankstellenConfigEntry, TankstellenCoordinator
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
@@ -133,7 +132,7 @@ async def _async_register_card(hass: HomeAssistant) -> None:
         )
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: TankstellenConfigEntry) -> bool:
     """Set up Tankstellen Austria from a config entry."""
     coordinator = TankstellenCoordinator(hass, entry)
     coordinator.async_setup()
@@ -159,11 +158,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     return True
 
 
-async def _async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
+async def _async_reload_entry(hass: HomeAssistant, entry: TankstellenConfigEntry) -> None:
     """Reload the config entry when options are updated."""
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: TankstellenConfigEntry) -> bool:
     """Unload a config entry."""
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/tankstellen_austria/config_flow.py
+++ b/custom_components/tankstellen_austria/config_flow.py
@@ -35,7 +35,6 @@ from homeassistant.helpers.selector import (
 from .const import (
     API_BASE_URL,
     API_ENDPOINT,
-    CARD_VERSION,
     CONF_DYNAMIC_ENTITY,
     CONF_FUEL_TYPES,
     CONF_INCLUDE_CLOSED,
@@ -46,6 +45,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     FUEL_TYPES,
+    USER_AGENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +67,7 @@ async def _test_api_connection(
         resp = await session.get(
             url,
             params=params,
-            headers={"User-Agent": f"HomeAssistant tankstellen_austria/{CARD_VERSION}"},
+            headers={"User-Agent": USER_AGENT},
             timeout=aiohttp.ClientTimeout(total=10),
         )
         resp.raise_for_status()

--- a/custom_components/tankstellen_austria/const.py
+++ b/custom_components/tankstellen_austria/const.py
@@ -1,4 +1,7 @@
 """Constants for Tankstellen Austria."""
+from typing import Final
+
+from homeassistant.const import __version__ as _HA_VERSION
 
 DOMAIN = "tankstellen_austria"
 CONF_LATITUDE = "latitude"
@@ -31,6 +34,18 @@ DYNAMIC_SAFETY_INTERVAL_HOURS = 6      # fallback timer when no movement detecte
 DOMAIN_LAST_API_CALL_KEY = "last_api_call"
 
 CARD_VERSION = "1.7.0-beta-1"
+
+# Integration version — tracks manifest.json "version" (always the clean
+# release name, never a beta suffix). Kept separate from CARD_VERSION so the
+# served JS bundle and the Python integration can be released independently
+# without breaking the frontend WS version check.
+INTEGRATION_VERSION: Final = "1.7.0"
+
+# Canonical HTTP User-Agent for upstream API calls. RFC-9110 format:
+# `<product>/<version> <product>/<version>` with a single space between
+# tokens — parsers treat the string as one opaque identifier if the first
+# slash is missing.
+USER_AGENT: Final = f"HomeAssistant/{_HA_VERSION} {DOMAIN}/{INTEGRATION_VERSION}"
 
 # Retry delay when the API returns no station data (e.g. mid-update window)
 NO_DATA_RETRY_MINUTES = 10

--- a/custom_components/tankstellen_austria/coordinator.py
+++ b/custom_components/tankstellen_austria/coordinator.py
@@ -87,6 +87,7 @@ class TankstellenCoordinator(DataUpdateCoordinator[dict[str, list[dict[str, Any]
             hass,
             _LOGGER,
             name=DOMAIN,
+            config_entry=entry,
             update_interval=interval,
         )
 

--- a/custom_components/tankstellen_austria/coordinator.py
+++ b/custom_components/tankstellen_austria/coordinator.py
@@ -405,3 +405,11 @@ class TankstellenCoordinator(DataUpdateCoordinator[dict[str, list[dict[str, Any]
             if len(stations) >= 5:
                 break
         return stations
+
+
+# Typed ConfigEntry alias — parameterises the generic ConfigEntry with the
+# runtime_data payload so `entry.runtime_data` is `TankstellenCoordinator`
+# without an explicit annotation at every call site. Defined after the class
+# so the forward reference resolves naturally. PEP 695 `type` statement
+# uses lazy evaluation, so Python 3.12+ only.
+type TankstellenConfigEntry = ConfigEntry[TankstellenCoordinator]

--- a/custom_components/tankstellen_austria/coordinator.py
+++ b/custom_components/tankstellen_austria/coordinator.py
@@ -10,7 +10,6 @@ from typing import Any
 import aiohttp
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import __version__ as HA_VERSION
 from homeassistant.core import Event, HomeAssistant, State, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -26,7 +25,6 @@ from homeassistant.util.location import distance
 from .const import (
     API_BASE_URL,
     API_ENDPOINT,
-    CARD_VERSION,
     CONF_DYNAMIC_ENTITY,
     CONF_FUEL_TYPES,
     CONF_INCLUDE_CLOSED,
@@ -41,6 +39,7 @@ from .const import (
     DYNAMIC_DOMAIN_COOLDOWN_MINUTES,
     DYNAMIC_SAFETY_INTERVAL_HOURS,
     NO_DATA_RETRY_MINUTES,
+    USER_AGENT,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -340,9 +339,7 @@ class TankstellenCoordinator(DataUpdateCoordinator[dict[str, list[dict[str, Any]
             "fuelType": fuel_type,
             "includeClosed": str(self._include_closed).lower(),
         }
-        headers = {
-            "User-Agent": f"HomeAssistant/{HA_VERSION} tankstellen_austria/{CARD_VERSION}",
-        }
+        headers = {"User-Agent": USER_AGENT}
         timeout = aiohttp.ClientTimeout(total=30)
         try:
             resp = await self._session.get(url, params=params, headers=headers, timeout=timeout)

--- a/custom_components/tankstellen_austria/diagnostics.py
+++ b/custom_components/tankstellen_austria/diagnostics.py
@@ -4,17 +4,16 @@ from __future__ import annotations
 from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
 from .const import CONF_LATITUDE, CONF_LONGITUDE
-from .coordinator import TankstellenCoordinator
+from .coordinator import TankstellenConfigEntry
 
 TO_REDACT = {"latitude", "longitude", CONF_LATITUDE, CONF_LONGITUDE}
 
 
 async def async_get_config_entry_diagnostics(
-    hass: HomeAssistant, entry: ConfigEntry
+    hass: HomeAssistant, entry: TankstellenConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry.
 
@@ -22,7 +21,7 @@ async def async_get_config_entry_diagnostics(
     location data are not redacted — they are operator-public and useful
     for reproducing issues.
     """
-    coordinator: TankstellenCoordinator = entry.runtime_data
+    coordinator = entry.runtime_data
     data = coordinator.data or {}
     return {
         "entry": {

--- a/custom_components/tankstellen_austria/sensor.py
+++ b/custom_components/tankstellen_austria/sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_FUEL_TYPES, DOMAIN, FUEL_TYPES
-from .coordinator import TankstellenCoordinator
+from .coordinator import TankstellenConfigEntry, TankstellenCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,11 +39,12 @@ PARALLEL_UPDATES = 0
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    entry: ConfigEntry,
+    entry: TankstellenConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up sensor entities from a config entry."""
-    coordinator: TankstellenCoordinator = entry.runtime_data
+    # Alias carries the runtime_data type — no local annotation needed.
+    coordinator = entry.runtime_data
     config = {**entry.data, **entry.options}
     fuel_types: list[str] = config[CONF_FUEL_TYPES]
 


### PR DESCRIPTION
## Summary

Three small, independently-verifiable compliance fixes flagged by the 2026 audit against the updated \`ha-integration-platinum\` skill:

### A1 — Typed \`ConfigEntry\` alias ([41942c2](https://github.com/rolandzeiner/tankstellen-austria/commit/41942c2))

\`coordinator.py\` gains

\`\`\`python
type TankstellenConfigEntry = ConfigEntry[TankstellenCoordinator]
\`\`\`

and \`__init__.py\` / \`sensor.py\` / \`diagnostics.py\` use the alias wherever they touch \`entry.runtime_data\`. The explicit \`coordinator: TankstellenCoordinator = entry.runtime_data\` annotation can be dropped — the alias carries the type.

\`config_flow.py\` keeps plain \`ConfigEntry\` on \`async_get_options_flow\` — narrowing a staticmethod override at that boundary risks a Liskov violation under \`mypy --strict\`, and the options flow never touches runtime_data.

### A2 — Explicit \`config_entry=entry\` on the coordinator ([58b6bab](https://github.com/rolandzeiner/tankstellen-austria/commit/58b6bab))

\`DataUpdateCoordinator\` in HA 2025.11 deprecated the implicit \`config_entry\` ContextVar fallback; HA 2026.8 will remove it. One-line fix: pass it explicitly.

### A3 — Canonical \`USER_AGENT\` constant ([dee3719](https://github.com/rolandzeiner/tankstellen-austria/commit/dee3719))

Fixes two real bugs in outbound API headers:

1. \`config_flow.py\`'s connection test sent \`"HomeAssistant tankstellen_austria/1.7.0-beta-1"\` — missing the slash between \`HomeAssistant\` and the HA version. RFC-9110 parsers treat that as one opaque token.
2. Both headers (connection test + coordinator fetch) derived the integration-version half from \`CARD_VERSION\`, which tracks the served JS bundle. A card beta (\`-beta-N\`) would leak into the backend UA even though the integration itself didn't change.

Adds \`INTEGRATION_VERSION\` (mirrors manifest \`version\`, always clean) and \`USER_AGENT\` to \`const.py\`; both call sites import and reference \`USER_AGENT\`. \`HA_VERSION\` / \`CARD_VERSION\` imports drop where they were only used for headers.

## Test plan

- [x] \`ruff check\` clean
- [x] \`mypy --strict --ignore-missing-imports custom_components/tankstellen_austria\` clean
- [x] \`pytest tests/ -q\` — 52/52 pass
- [ ] Live smoke test on dev HA — all sensors still report prices after restart; config flow + options flow + reconfigure still work
- [ ] CI: \`validate-hacs\`, \`validate-hassfest\`, \`tests\`, \`validate-card\`

## Out of scope

- Stage B (card refactor) landed separately in #18 / \`v1.7.0-beta-1\`.
- A4 (coverage reporting in CI) — skipped unless you want it as a follow-up.