### PR TITLE
test: close two Platinum coverage gaps (UA header, options-flow cannot_connect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,6 @@ This can be used directly in automations and templates, e.g. to alert when the c
 - **Rate limit**: Don't poll more than every 10 minutes (60 minutes is safe)
 - **No API key** required
 - Returns 5 cheapest stations (with prices) + surrounding stations (without)
-- All requests include a `User-Agent` header identifying the integration and HA version
 
 ### Important Notes
 

--- a/custom_components/tankstellen_austria/quality_scale.yaml
+++ b/custom_components/tankstellen_austria/quality_scale.yaml
@@ -69,7 +69,7 @@ rules:
     comment: The E-Control API requires no authentication.
   test-coverage:
     status: done
-    comment: Config flow, coordinator (fetch, failure, partial-failure resilience, dynamic mode guards, no-data retry), and sensor (state, attributes, dynamic mode) tests are all covered.
+    comment: Config flow (incl. user/options/reconfigure cannot_connect paths and canonical User-Agent header), coordinator (fetch, failure, partial-failure resilience, dynamic mode guards, no-data retry, canonical User-Agent header), and sensor (state, attributes, dynamic mode) tests are all covered.
 
   # Gold
   devices:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,5 @@
 """Tests for the Tankstellen Austria config flow."""
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
@@ -12,6 +12,7 @@ from custom_components.tankstellen_austria.const import (
     CONF_LONGITUDE,
     CONF_SCAN_INTERVAL,
     DOMAIN,
+    USER_AGENT,
 )
 
 VALID_USER_INPUT = {
@@ -146,6 +147,65 @@ async def test_form_cannot_connect(hass: HomeAssistant) -> None:
         )
     assert result["type"] == FlowResultType.FORM
     assert result["errors"].get("base") == "cannot_connect"
+
+
+async def test_options_flow_cannot_connect(hass: HomeAssistant, mock_fetch) -> None:
+    """Options-flow submission with an API failure redisplays the form with cannot_connect.
+
+    Parallel to test_form_cannot_connect (user flow) and
+    test_reconfigure_cannot_connect (reconfigure flow) — the options flow
+    took the same code path but had no regression guard.
+    """
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": config_entries.SOURCE_USER}
+    )
+    await hass.config_entries.flow.async_configure(result["flow_id"], VALID_USER_INPUT)
+    entry = hass.config_entries.async_entries(DOMAIN)[0]
+
+    options = await hass.config_entries.options.async_init(entry.entry_id)
+    with patch(
+        "custom_components.tankstellen_austria.config_flow._test_api_connection",
+        new_callable=AsyncMock,
+        return_value=False,
+    ):
+        result = await hass.config_entries.options.async_configure(
+            options["flow_id"],
+            {
+                "location": {"latitude": 48.1478, "longitude": 16.5147},
+                CONF_FUEL_TYPES: ["DIE"],
+                CONF_INCLUDE_CLOSED: True,
+                CONF_SCAN_INTERVAL: 30,
+            },
+        )
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"].get("base") == "cannot_connect"
+
+
+async def test_connection_test_sends_canonical_user_agent(hass: HomeAssistant) -> None:
+    """_test_api_connection sends the USER_AGENT constant (RFC-9110).
+
+    Regression guard. Before v1.7.0 this call site sent
+    'HomeAssistant tankstellen_austria/...' — missing the slash after
+    HomeAssistant, making it RFC-9110-nonconformant. Parsers treat such a
+    token as one opaque identifier, not a versioned product string. Any
+    future inline-string regression here fails this test.
+    """
+    from custom_components.tankstellen_austria.config_flow import _test_api_connection
+
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    session = MagicMock()
+    session.get = AsyncMock(return_value=resp)
+
+    with patch(
+        "custom_components.tankstellen_austria.config_flow.async_get_clientsession",
+        return_value=session,
+    ):
+        assert await _test_api_connection(hass, 48.0, 16.0, "DIE") is True
+
+    assert session.get.called
+    headers = session.get.call_args.kwargs["headers"]
+    assert headers == {"User-Agent": USER_AGENT}
 
 
 async def test_options_flow_no_fuel_type(hass: HomeAssistant, mock_fetch) -> None:

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -97,6 +97,46 @@ async def test_api_failure_raises_update_failed(hass: HomeAssistant) -> None:
         await coordinator._async_update_data()
 
 
+async def test_coordinator_fetch_sends_canonical_user_agent(hass: HomeAssistant) -> None:
+    """coordinator._fetch sends RFC-9110 UA: HomeAssistant/<ver> tankstellen_austria/<int_ver>.
+
+    Regression guard. Before v1.7.0 the integration's outbound User-Agent was
+    derived from CARD_VERSION (which carries a -beta-N suffix during card
+    development), leaking card betas into the backend UA. The canonical
+    constant in const.py decouples the two. If someone later inlines a
+    different header string here, this test fails loudly.
+    """
+    from homeassistant.const import __version__ as HA_VERSION
+
+    from custom_components.tankstellen_austria.const import (
+        DOMAIN as TS_DOMAIN,
+        INTEGRATION_VERSION,
+        USER_AGENT,
+    )
+
+    # Canonical format: two space-separated product tokens, each with a slash.
+    assert USER_AGENT == f"HomeAssistant/{HA_VERSION} {TS_DOMAIN}/{INTEGRATION_VERSION}"
+
+    entry = _make_entry()
+    entry.add_to_hass(hass)
+    coordinator = TankstellenCoordinator(hass, entry)
+
+    # Substitute a session mock whose .get() is awaitable and returns an empty
+    # station list — enough for _fetch to reach the resp.json() path without
+    # raising, so we can inspect the outgoing headers.
+    resp = MagicMock()
+    resp.raise_for_status = MagicMock()
+    resp.json = AsyncMock(return_value=[])
+    coordinator._session = MagicMock()
+    coordinator._session.get = AsyncMock(return_value=resp)
+
+    await coordinator._fetch("DIE", 48.0, 16.0)
+
+    assert coordinator._session.get.called
+    headers = coordinator._session.get.call_args.kwargs["headers"]
+    assert headers == {"User-Agent": USER_AGENT}
+
+
 async def test_config_entry_not_ready_on_first_refresh_failure(
     hass: HomeAssistant,
 ) -> None:


### PR DESCRIPTION
## Summary

Closes two should-have gaps surfaced by the test-suite audit. The v1.6.0 → v1.7.0-beta-2 suite was strong (52/52 assertions, no false positives), but two tests would have caught real bugs that shipped unnoticed:

### 1. UA header canonicalization

The new \`USER_AGENT\` constant landed in v1.7.0-beta-2 without a regression test. The bug it fixed (\`\"HomeAssistant tankstellen_austria/...\"\` — missing the slash after \`HomeAssistant\`, RFC-9110-nonconformant) shipped undetected precisely because nothing asserted the outbound header shape.

- [\`test_coordinator.py\`](tests/test_coordinator.py): \`test_coordinator_fetch_sends_canonical_user_agent\` — asserts \`USER_AGENT == f\"HomeAssistant/{HA_VERSION} {DOMAIN}/{INTEGRATION_VERSION}\"\` (format) AND patches \`coordinator._session.get\` to capture the headers kwarg from a real \`_fetch\` call.
- [\`test_config_flow.py\`](tests/test_config_flow.py): \`test_connection_test_sends_canonical_user_agent\` — patches the session and calls \`_test_api_connection\` directly, asserting the \`headers\` kwarg equals \`{\"User-Agent\": USER_AGENT}\`.

### 2. Options-flow \`cannot_connect\`

\`test_form_cannot_connect\` (user flow, line 133) and \`test_reconfigure_cannot_connect\` (line 231) both existed, but the parallel options-flow code path ([\`config_flow.py:290+\`](custom_components/tankstellen_austria/config_flow.py#L290)) had no test.

- [\`test_config_flow.py\`](tests/test_config_flow.py): \`test_options_flow_cannot_connect\` — drives the options flow with a patched \`_test_api_connection\` returning False; asserts the form redisplays with \`errors[\"base\"] == \"cannot_connect\"\`.

### Peripheral changes

- \`quality_scale.yaml\`: \`test-coverage\` comment updated to mention the new assertions.
- \`README.md\`: drops the \"All requests include a \`User-Agent\` header...\" bullet from §API Info. It was implementation-detail handshake docs; now that a test guards the behaviour, the bullet is redundant.

## Test plan

- [x] \`ruff check .\` clean
- [x] \`mypy --strict --ignore-missing-imports custom_components/tankstellen_austria\` clean
- [x] \`pytest tests/ -q\` — 55/55 pass (52 pre-existing + 3 new)
- [ ] CI: \`validate-hacs\`, \`validate-hassfest\`, \`tests\`, \`validate-card\`

## Nice-to-haves not included

Rest of the audit's recommendations (no-data-retry callback end-to-end, explicit tracker-change refresh, entry setup → platform-forward chain, \`ir.async_create_issue\` call-count spy) were judged below the \"should-have\" bar. Happy to circle back if any of them turn out to matter later.